### PR TITLE
 Spelling, Removed extra text for formatting.

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,7 +22,7 @@
 
                 <div class="titlecard">
                      <h1 class="text-center">CNA Presidential Election 2023 </h1>
-                     <h1 class="text-center">About Me: Your Advocate for a Better College Experience</h1>  
+                     <h1 class="text-center">Your Advocate for a Better College Experience</h1>  
                 </div>
 
                 <div class="spacer"></div>

--- a/platform.html
+++ b/platform.html
@@ -21,8 +21,8 @@
             <div class="row">
 
                 <div class="titlecard">
-                     <h1 class="text-center">CNA Presedential Election 2023 </h1>
-                     <h1 class="text-center">About Me: Your Advocate for a Better College Experience</h1>  
+                     <h1 class="text-center">CNA Presidential Election 2023 </h1>
+                     <h1 class="text-center">Your Advocate for a Better College Experience</h1>  
                 </div>
 
                 <div class="spacer"></div>


### PR DESCRIPTION
- Fixed spelling on platform page. 
- Removed extra "About Me:" in the titlecard's as it seemed unnecessary 

The text of the platform pages titlecard is a duplicate of about me. Is this intentional, if not it should be updated to a unique text.